### PR TITLE
Fix typo in ipath in rfkill.py

### DIFF
--- a/pyric/utils/rfkill.py
+++ b/pyric/utils/rfkill.py
@@ -61,7 +61,7 @@ RFKILL_STATE = [False,True] # Unblocked = 0, Blocked = 1
 """
 dpath = '/dev/rfkill'
 spath = '/sys/class/rfkill'
-ipath = 'sys/class/ieee80211' # directory of physical indexes
+ipath = '/sys/class/ieee80211' # directory of physical indexes
 
 def rfkill_list():
     """


### PR DESCRIPTION
Missing forward slash in the ipath resulting errors when rfkill could not be found.