### PR TITLE
README typo? Unused variable in example

### DIFF
--- a/README.md
+++ b/README.md
@@ -752,7 +752,7 @@ hw.randhw(ouis) # generate a random mac address
 hw.manufacturer(ouis,'00:03:f0:5a:a1:fc')
 => 'Redfern Broadband Networks'
 
-hw.ifcard('wlan0') # get driver & chipset
+hw.ifcard(dev) # get driver & chipset
 => ('iwlwifi', 'Intel 4965/5xxx/6xxx/1xxx')
 ```
 


### PR DESCRIPTION
See example context, `dev` is not used in example even though it's declared. Pring a fix that I found the most intuitive.