### PR TITLE
Update rfkill.py

### DIFF
--- a/pyric/utils/rfkill.py
+++ b/pyric/utils/rfkill.py
@@ -101,7 +101,7 @@ def rfkill_block(idx):
     try:
         rfke = rfkh.rfkill_event(idx,rfkh.RFKILL_TYPE_ALL,rfkh.RFKILL_OP_CHANGE,1,0)
         if _PY3_: rfke = rfke.decode('ascii')
-        fout = open(dpath, 'w')
+        fout = open(dpath, 'wb')
         fout.write(rfke)
     except struct.error as e:
         raise pyric.error(pyric.EUNDEF,"Error packing rfkill event {0}".format(e))
@@ -131,7 +131,7 @@ def rfkill_unblock(idx):
     fout = None
     try:
         rfke = rfkh.rfkill_event(idx,rfkh.RFKILL_TYPE_ALL,rfkh.RFKILL_OP_CHANGE,0,0)
-        fout = open(dpath, 'w')
+        fout = open(dpath, 'wb')
         fout.write(rfke)
     except struct.error as e:
         raise pyric.error(pyric.EUNDEF,"Error packing rfkill event {0}".format(e))


### PR DESCRIPTION
Fix typing issue that expects string rather than the correct bytes object.